### PR TITLE
feat(auth): add functionality to refresh access token.

### DIFF
--- a/server/src/routes/auth.routes.ts
+++ b/server/src/routes/auth.routes.ts
@@ -3,6 +3,7 @@ import {
 	registerUser,
 	loginUser,
 	logoutUser,
+	refreshAccessToken,
 } from "../controllers/auth.controllers.js";
 import {
 	userSignUpInputValidators,
@@ -32,5 +33,5 @@ router.post("/logout", logoutUser);
 router.get("/admin-route", authenticateUser, isAdmin, (req, res) => {
 	res.json({ message: "accepted" });
 });
-
+router.post("/refresh-token", refreshAccessToken);
 export default router;

--- a/server/src/utils/token.utils.ts
+++ b/server/src/utils/token.utils.ts
@@ -1,5 +1,6 @@
 import jwt from "jsonwebtoken";
 import getEnv from "./env.utils.js";
+// import User from "../models/user.model.js";
 
 export interface JWTPayload {
 	userId: string;
@@ -16,3 +17,4 @@ export const generateRefreshToken = ({ userId, role }: JWTPayload): string => {
 		expiresIn: "7d",
 	});
 };
+


### PR DESCRIPTION
- the function checks the cookie for refresh token.
- then compares it with the database refresh token.
- if valid then new access and refresh tokens are generated.
- they are attached to cookie and the database token is rotated for security reasons.
- also added an endpoint for refreshing the token.

## Summary by Sourcery

Implement a cookie-based token refresh flow by adding a refresh endpoint, rotating tokens in the database, and updating authentication middleware and routes to use HTTP-only cookies for access and refresh tokens.

New Features:
- Introduce a /refresh-token endpoint to issue new access and refresh tokens via cookies
- Set accessToken alongside refreshToken in HTTP-only cookies upon login and refresh

Enhancements:
- Rotate refresh tokens in the database for improved security
- Update authenticateUser middleware to read accessToken from cookie and handle expired/invalid tokens
- Clear both accessToken and refreshToken cookies on logout
- Consistently apply secure, httpOnly, and sameSite cookie settings based on environment